### PR TITLE
feature: ExternalOrder and Microservice endpoints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,14 +21,14 @@
         }
     },
     "require": {
-        "php": "^7.1",
+        "php": "^7.1|^8.0",
         "ext-json": "*",
-        "symfony/http-client": "^4.4|^5",
+        "symfony/http-client": "^4.4|^5|^6",
         "giggsey/libphonenumber-for-php": "^8.12"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.5",
-        "fzaninotto/faker": "^1.9"
+        "phpunit/phpunit": "^9.5",
+        "fakerphp/faker": "^1.9"
     },
     "config": {
         "lock": false

--- a/src/Client.php
+++ b/src/Client.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Boekuwzending;
 
+use Boekuwzending\Endpoints\IntegrationEndpoint;
 use Boekuwzending\Endpoints\LabelEndpoint;
 use Boekuwzending\Endpoints\MeEndpoint;
 use Boekuwzending\Endpoints\OrderEndpoint;
@@ -28,6 +29,8 @@ class Client
 {
     public const METHOD_GET = 'GET';
     public const METHOD_POST = 'POST';
+    public const METHOD_PUT = 'PUT';
+    public const METHOD_DELETE = 'DELETE';
 
     public const ENVIRONMENT_LIVE = 'live';
     public const ENVIRONMENT_STAGING = 'staging';
@@ -91,6 +94,11 @@ class Client
     public $order;
 
     /**
+     * @var IntegrationEndpoint
+     */
+    public $integration;
+
+    /**
      * @var array
      */
     private $additionalUserAgents = [];
@@ -116,6 +124,11 @@ class Client
     {
         $this->clientId = $clientId;
         $this->clientSecret = $clientSecret;
+    }
+
+    public function setAccessToken(string $accessToken): void
+    {
+        $this->accessToken = $accessToken;
     }
 
     /**
@@ -169,7 +182,7 @@ class Client
             $response = $this->httpClient->request($method, $url, [
                 'headers' => [
                     'Authorization' => sprintf('Bearer %s', $this->accessToken),
-                    'User-Agent' => implode(' ', $this->additionalUserAgents)
+                    'User-Agent' => implode(' ', $this->additionalUserAgents),
                 ],
                 'json' => $body,
                 'query' => $query
@@ -201,6 +214,7 @@ class Client
         $this->service = new ServiceEndpoint($this, $serializer);
         $this->rates = new RateEndpoint($this, $serializer);
         $this->order = new OrderEndpoint($this, $serializer);
+        $this->integration = new IntegrationEndpoint($this, $serializer);
     }
 
     /**

--- a/src/ClientFactory.php
+++ b/src/ClientFactory.php
@@ -36,7 +36,7 @@ class ClientFactory
      */
     public static function buildClient(string $environment = Client::ENVIRONMENT_LIVE): Client
     {
-        $baseUriOverride = getenv('BUZ_API_URL');
+        $baseUriOverride = getenv('BUZ_API_BASE_URL');
 
         $httpClientOptions = [];
 

--- a/src/ClientFactory.php
+++ b/src/ClientFactory.php
@@ -7,12 +7,11 @@ namespace Boekuwzending;
 use Boekuwzending\Serializer\Serializer;
 use Symfony\Component\HttpClient\HttpClient;
 
-/**
- * Class BuzApiClientFactory.
- */
 class ClientFactory
 {
     /**
+     * Builds a client that authenticates using client ID and secret.
+     *
      * @param string $clientId
      * @param string $clientSecret
      * @param string $environment
@@ -24,6 +23,18 @@ class ClientFactory
         string $clientSecret,
         string $environment = Client::ENVIRONMENT_LIVE
     ): Client
+    {
+        $client = self::buildClient($environment);
+
+        $client->setCredentials($clientId, $clientSecret);
+
+        return $client;
+    }
+
+    /**
+     * Builds an unauthenticated client.
+     */
+    public static function buildClient(string $environment = Client::ENVIRONMENT_LIVE): Client
     {
         $baseUriOverride = getenv('BUZ_API_URL');
 
@@ -39,9 +50,6 @@ class ClientFactory
         $serializer = new Serializer();
         $httpClient = HttpClient::createForBaseUri($baseUri, $httpClientOptions);
 
-        $client = new Client($httpClient, $serializer);
-        $client->setCredentials($clientId, $clientSecret);
-
-        return $client;
+        return new Client($httpClient, $serializer);
     }
 }

--- a/src/Endpoints/IntegrationEndpoint.php
+++ b/src/Endpoints/IntegrationEndpoint.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Boekuwzending\Endpoints;
+
+use Boekuwzending\Client;
+use Boekuwzending\Exception\AuthorizationFailedException;
+use Boekuwzending\Exception\RequestFailedException;
+use Boekuwzending\Resource\Integration;
+use Boekuwzending\Resource\ShopifyIntegration;
+use InvalidArgumentException;
+
+class IntegrationEndpoint extends AbstractEndpoint
+{
+    /**
+     * @throws AuthorizationFailedException
+     * @throws RequestFailedException
+     */
+    public function create(Integration $integration): Integration
+    {
+        if (get_class($integration) !== ShopifyIntegration::class) {
+            throw new InvalidArgumentException('Unsupported integration type');
+        }
+
+        $query = [];
+        if (isset($_COOKIE['XDEBUG_SESSION'])) {
+            $query['XDEBUG_SESSION'] = $_COOKIE['XDEBUG_SESSION'];
+        }
+
+        $data = $this->client->request(
+            '/integrations/shopify',
+            Client::METHOD_POST,
+            $this->serializer->serialize($integration),
+            $query,
+        );
+
+        return $this->serializer->deserialize($data, ShopifyIntegration::class);
+    }
+}

--- a/src/Endpoints/OrderEndpoint.php
+++ b/src/Endpoints/OrderEndpoint.php
@@ -42,18 +42,21 @@ class OrderEndpoint extends AbstractEndpoint
     }
 
     /**
-     * @return array<Order>
+     * @return array<OrderOverview>
      *
      * @throws AuthorizationFailedException
      * @throws RequestFailedException
      */
-    public function findByExternalId(string $externalId): array
+    public function findByExternalId(string $externalId, bool $includeArchived = true): array
     {
         $data = $this->client->request(
             '/orders',
             Client::METHOD_GET,
             [],
-            ['externalId' => $externalId]
+            [
+                'externalId' => $externalId,
+                'includeArchived' => $includeArchived
+            ]
         );
 
         $orders = [];
@@ -88,7 +91,7 @@ class OrderEndpoint extends AbstractEndpoint
     {
         $this->client->request(
             '/orders/'.$order->getId(),
-            Client::METHOD_DELETE,
+            Client::METHOD_DELETE
         );
     }
 }

--- a/src/Endpoints/OrderEndpoint.php
+++ b/src/Endpoints/OrderEndpoint.php
@@ -8,6 +8,7 @@ use Boekuwzending\Client;
 use Boekuwzending\Exception\AuthorizationFailedException;
 use Boekuwzending\Exception\RequestFailedException;
 use Boekuwzending\Resource\Order;
+use Boekuwzending\Resource\OrderOverview;
 
 /**
  * Class OrderEndpoint.
@@ -15,23 +16,17 @@ use Boekuwzending\Resource\Order;
 class OrderEndpoint extends AbstractEndpoint
 {
     /**
-     * @param string $id
-     *
-     * @return Order
      * @throws AuthorizationFailedException
      * @throws RequestFailedException
      */
     public function get(string $id): Order
     {
-        $response = $this->client->request('/orders/' . $id, Client::METHOD_GET);
+        $response = $this->client->request('/orders/'.$id, Client::METHOD_GET);
 
         return $this->serializer->deserialize($response, Order::class);
     }
 
     /**
-     * @param Order $order
-     *
-     * @return Order
      * @throws AuthorizationFailedException
      * @throws RequestFailedException
      */
@@ -44,5 +39,56 @@ class OrderEndpoint extends AbstractEndpoint
         );
 
         return $this->serializer->deserialize($data, Order::class);
+    }
+
+    /**
+     * @return array<Order>
+     *
+     * @throws AuthorizationFailedException
+     * @throws RequestFailedException
+     */
+    public function findByExternalId(string $externalId): array
+    {
+        $data = $this->client->request(
+            '/orders',
+            Client::METHOD_GET,
+            [],
+            ['externalId' => $externalId]
+        );
+
+        $orders = [];
+
+        foreach ($data as $order) {
+            $orders[] = $this->serializer->deserialize($order, OrderOverview::class);
+        }
+
+        return $orders;
+    }
+
+    /**
+     * @throws AuthorizationFailedException
+     * @throws RequestFailedException
+     */
+    public function update(Order $order): Order
+    {
+        $data = $this->client->request(
+            '/orders/'.$order->getId(),
+            Client::METHOD_PUT,
+            $this->serializer->serialize($order)
+        );
+
+        return $this->serializer->deserialize($data, Order::class);
+    }
+
+    /**
+     * @throws AuthorizationFailedException
+     * @throws RequestFailedException
+     */
+    public function delete(Order $order): void
+    {
+        $this->client->request(
+            '/orders/'.$order->getId(),
+            Client::METHOD_DELETE,
+        );
     }
 }

--- a/src/Resource/ClientCredentials.php
+++ b/src/Resource/ClientCredentials.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Boekuwzending\Resource;
+
+class ClientCredentials
+{
+    /** @var string */
+    private $identifier;
+
+    /** @var string */
+    private $secret;
+
+    public function getIdentifier(): string
+    {
+        return $this->identifier;
+    }
+
+    public function setIdentifier(string $identifier): void
+    {
+        $this->identifier = $identifier;
+    }
+
+    public function getSecret(): string
+    {
+        return $this->secret;
+    }
+
+    public function setSecret(string $secret): void
+    {
+        $this->secret = $secret;
+    }
+}

--- a/src/Resource/Integration.php
+++ b/src/Resource/Integration.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Boekuwzending\Resource;
+
+abstract class Integration
+{
+    private $id;
+
+    private $shopUrl;
+
+    private $externalAccountId;
+
+    private $relation;
+
+    private $client;
+
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+
+    public function setId(?string $id): void
+    {
+        $this->id = $id;
+    }
+
+    public function getShopUrl(): string
+    {
+        return $this->shopUrl;
+    }
+
+    public function setShopUrl(string $shopUrl): void
+    {
+        $this->shopUrl = $shopUrl;
+    }
+
+    public function getExternalAccountId(): string
+    {
+        return $this->externalAccountId;
+    }
+
+    public function setExternalAccountId(string $externalAccountId): void
+    {
+        $this->externalAccountId = $externalAccountId;
+    }
+
+    public function getRelation(): Relation
+    {
+        return $this->relation;
+    }
+
+    public function setRelation(Relation $relation): void
+    {
+        $this->relation = $relation;
+    }
+
+    public function getClient(): ClientCredentials
+    {
+        return $this->client;
+    }
+
+    public function setClient(ClientCredentials $client): void
+    {
+        $this->client = $client;
+    }
+}

--- a/src/Resource/Me.php
+++ b/src/Resource/Me.php
@@ -25,6 +25,11 @@ class Me
     private $id;
 
     /**
+     * @var Relation|null
+     */
+    private $relation;
+
+    /**
      * @return string
      */
     public function getNumber(): ?string
@@ -67,5 +72,15 @@ class Me
     public function setId(string $id): void
     {
         $this->id = $id;
+    }
+
+    public function getRelation(): ?Relation
+    {
+        return $this->relation;
+    }
+
+    public function setRelation(?Relation $relation): void
+    {
+        $this->relation = $relation;
     }
 }

--- a/src/Resource/Order.php
+++ b/src/Resource/Order.php
@@ -15,6 +15,11 @@ class Order
     protected $id;
 
     /**
+     * @var bool
+     */
+    protected $archived;
+
+    /**
      * @var string
      */
     protected $externalId;
@@ -151,5 +156,21 @@ class Order
     public function setShipToAddress(Address $shipToAddress): void
     {
         $this->shipToAddress = $shipToAddress;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isArchived(): bool
+    {
+        return $this->archived;
+    }
+
+    /**
+     * @param bool $archived
+     */
+    public function setArchived(bool $archived): void
+    {
+        $this->archived = $archived;
     }
 }

--- a/src/Resource/OrderOverview.php
+++ b/src/Resource/OrderOverview.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Boekuwzending\Resource;
+
+/**
+ * Class OrderOverview
+ */
+class OrderOverview
+{
+    /**
+     * @var string
+     */
+    protected $id;
+
+    /**
+     * @var string
+     */
+    protected $externalId;
+
+    /**
+     * @var string|null
+     */
+    protected $reference;
+
+    public function __construct($id = null)
+    {
+        $this->id = $id;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getId(): ?string
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getExternalId(): string
+    {
+        return $this->externalId;
+    }
+
+    /**
+     * @param string $externalId
+     */
+    public function setExternalId(string $externalId): void
+    {
+        $this->externalId = $externalId;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getReference(): ?string
+    {
+        return $this->reference;
+    }
+
+    /**
+     * @param string|null $reference
+     */
+    public function setReference(?string $reference): void
+    {
+        $this->reference = $reference;
+    }
+}

--- a/src/Resource/OrderOverview.php
+++ b/src/Resource/OrderOverview.php
@@ -22,6 +22,11 @@ class OrderOverview
      */
     protected $reference;
 
+    /**
+     * @var bool
+     */
+    protected $archived;
+
     public function __construct($id = null)
     {
         $this->id = $id;
@@ -65,5 +70,21 @@ class OrderOverview
     public function setReference(?string $reference): void
     {
         $this->reference = $reference;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isArchived(): bool
+    {
+        return $this->archived;
+    }
+
+    /**
+     * @param bool $archived
+     */
+    public function setArchived(bool $archived): void
+    {
+        $this->archived = $archived;
     }
 }

--- a/src/Resource/Relation.php
+++ b/src/Resource/Relation.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Boekuwzending\Resource;
+
+class Relation
+{
+    private $id;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setId($id): void
+    {
+        $this->id = $id;
+    }
+}

--- a/src/Resource/ShopifyIntegration.php
+++ b/src/Resource/ShopifyIntegration.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Boekuwzending\Resource;
+
+class ShopifyIntegration extends Integration
+{
+
+}

--- a/src/Resource/TrackingDetail.php
+++ b/src/Resource/TrackingDetail.php
@@ -28,15 +28,15 @@ class TrackingDetail {
     /**
      * @return string
      */
-    public function getStatus(): string
+    public function getStatus(): ?string
     {
         return $this->status;
     }
 
     /**
-     * @param string $status
+     * @param ?string $status
      */
-    public function setStatus(string $status): void
+    public function setStatus(?string $status): void
     {
         $this->status = $status;
     }

--- a/src/Serializer/ClientSerializer.php
+++ b/src/Serializer/ClientSerializer.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Boekuwzending\Serializer;
+
+use Boekuwzending\Resource\ClientCredentials;
+
+class ClientSerializer implements SerializerInterface
+{
+    public function serialize($data): array
+    {
+        return [];
+    }
+
+    public function deserialize(array $data, string $dataType)
+    {
+        $client = new ClientCredentials();
+
+        $client->setIdentifier($data['identifier']);
+        $client->setSecret($data['secret']);
+
+        return $client;
+    }
+}

--- a/src/Serializer/IntegrationSerializer.php
+++ b/src/Serializer/IntegrationSerializer.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Boekuwzending\Serializer;
+
+use Boekuwzending\Resource\ClientCredentials;
+use Boekuwzending\Resource\Integration;
+use Boekuwzending\Resource\Relation;
+use Exception;
+
+class IntegrationSerializer implements SerializerInterface
+{
+    /**
+     * @param Integration $data
+     */
+    public function serialize($data): array
+    {
+        $response = [
+            'id' => $data->getId(),
+            'externalAccountId' => $data->getExternalAccountId(),
+            'shopUrl' => $data->getShopUrl(),
+        ];
+
+        if (null !== ($relation = $data->getRelation())) {
+            $response['relation'] = 'relations/'.$relation->getId();
+        }
+
+        return $response;
+    }
+
+    /**
+     * @inheritDoc
+     * @throws Exception
+     *
+     * @param class-string $dataType
+     */
+    public function deserialize(array $data, string $dataType)
+    {
+        /** @var Integration $object */
+        $object = new $dataType;
+
+        $object->setId($data['id']);
+        $object->setExternalAccountId($data['externalAccountId']);
+        $object->setShopUrl($data['shopUrl']);
+
+        $serializer = new Serializer();
+
+        if (!empty($data['relation'])) {
+            $object->setRelation($serializer->deserialize($data['relation'], Relation::class));
+        }
+
+        if (!empty($data['client'])) {
+            $object->setClient($serializer->deserialize($data['client'], ClientCredentials::class));
+        }
+
+        return $object;
+    }
+}

--- a/src/Serializer/MeSerializer.php
+++ b/src/Serializer/MeSerializer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Boekuwzending\Serializer;
 
 use Boekuwzending\Resource\Me;
+use Boekuwzending\Resource\Relation;
 
 /**
  * Class MeSerializer.
@@ -27,10 +28,15 @@ class MeSerializer implements SerializerInterface
      */
     public function deserialize(array $data, string $dataType): Me
     {
+        $serializer = new Serializer();
+
         $me = new Me();
-        $me->setId($data['id']);
-        $me->setNumber($data['number']);
+
+//        $me->setId($data['id']);
+//        $me->setNumber($data['number']);
         $me->setName($data['name']);
+
+        $me->setRelation($serializer->deserialize($data['relation'], Relation::class));
 
         return $me;
     }

--- a/src/Serializer/OrderOverviewSerializer.php
+++ b/src/Serializer/OrderOverviewSerializer.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Boekuwzending\Serializer;
+
+use Boekuwzending\Resource\Order;
+use Boekuwzending\Resource\OrderOverview;
+use Exception;
+use RuntimeException;
+
+/**
+ * Class OrderOverviewSerializer
+ */
+class OrderOverviewSerializer implements SerializerInterface
+{
+    /**
+     * @param Order $data
+     *
+     * @return array
+     */
+    public function serialize($data): array
+    {
+        throw new RuntimeException('Cannot serialize an OverOverview');
+    }
+
+    /**
+     * @param array $data
+     * @param string $dataType
+     * @return Order
+     * @throws Exception
+     */
+    public function deserialize(array $data, string $dataType): OrderOverview
+    {
+        $order = new OrderOverview($data['id']);
+
+        $order->setExternalId($data['externalId']);
+        $order->setReference($data['reference']);
+
+        return $order;
+    }
+}

--- a/src/Serializer/OrderOverviewSerializer.php
+++ b/src/Serializer/OrderOverviewSerializer.php
@@ -25,7 +25,7 @@ class OrderOverviewSerializer implements SerializerInterface
     /**
      * @param array $data
      * @param string $dataType
-     * @return Order
+     * @return OrderOverview
      * @throws Exception
      */
     public function deserialize(array $data, string $dataType): OrderOverview
@@ -34,6 +34,7 @@ class OrderOverviewSerializer implements SerializerInterface
 
         $order->setExternalId($data['externalId']);
         $order->setReference($data['reference']);
+        $order->setArchived($data['archived']);
 
         return $order;
     }

--- a/src/Serializer/OrderSerializer.php
+++ b/src/Serializer/OrderSerializer.php
@@ -55,6 +55,7 @@ class OrderSerializer implements SerializerInterface
         }
 
         $order = new Order($data['id']);
+        $order->setArchived($data['archived']);
         $order->setExternalId($data['externalId']);
         $order->setReference($data['reference']);
         $order->setCreatedAtSource(new DateTime($data['createdAtSource']));

--- a/src/Serializer/RelationSerializer.php
+++ b/src/Serializer/RelationSerializer.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Boekuwzending\Serializer;
+
+use Boekuwzending\Resource\Relation;
+
+class RelationSerializer implements SerializerInterface
+{
+    /**
+     * @param Relation $data
+     * @return array
+     */
+    public function serialize($data): array
+    {
+        return [
+            'id' => $data->getId(),
+        ];
+    }
+
+    /**
+     * @param array $data
+     * @param string $dataType
+     * @return Relation
+     */
+    public function deserialize(array $data, string $dataType): Relation
+    {
+        $rate = new Relation();
+
+        $rate->setId($data['id']);
+
+        return $rate;
+    }
+}

--- a/src/Serializer/Serializer.php
+++ b/src/Serializer/Serializer.php
@@ -6,6 +6,7 @@ namespace Boekuwzending\Serializer;
 
 use Boekuwzending\Exception\SerializerNotFoundException;
 use Boekuwzending\Resource\Address;
+use Boekuwzending\Resource\ClientCredentials;
 use Boekuwzending\Resource\Contact;
 use Boekuwzending\Resource\DeliveryInstruction;
 use Boekuwzending\Resource\Dimensions;
@@ -19,11 +20,14 @@ use Boekuwzending\Resource\Me;
 use Boekuwzending\Resource\Order;
 use Boekuwzending\Resource\OrderContact;
 use Boekuwzending\Resource\OrderLine;
+use Boekuwzending\Resource\OrderOverview;
 use Boekuwzending\Resource\PickupPoint;
 use Boekuwzending\Resource\Rate;
 use Boekuwzending\Resource\RateService;
+use Boekuwzending\Resource\Relation;
 use Boekuwzending\Resource\Service;
 use Boekuwzending\Resource\Shipment;
+use Boekuwzending\Resource\ShopifyIntegration;
 use Boekuwzending\Resource\TrackAndTrace;
 use Boekuwzending\Resource\TrackingDetail;
 
@@ -46,6 +50,7 @@ class Serializer implements SerializerInterface
             Shipment::class => new ShipmentSerializer(),
             Contact::class => new ContactSerializer(),
             Address::class => new AddressSerializer(),
+            ClientCredentials::class => new ClientSerializer(),
             DispatchInstruction::class => new InstructionSerializer(),
             DeliveryInstruction::class => new InstructionSerializer(),
             Item::class => new ItemSerializer(),
@@ -61,9 +66,12 @@ class Serializer implements SerializerInterface
             PickupPoint::class => new PickupPointSerializer(),
             Rate::class => new RateSerializer(),
             RateService::class => new RateServiceSerializer(),
+            Relation::class => new RelationSerializer(),
+            ShopifyIntegration::class => new IntegrationSerializer(),
             OrderContact::class => new OrderContactSerializer(),
             OrderLine::class => new OrderLineSerializer(),
-            Order::class => new OrderSerializer()
+            Order::class => new OrderSerializer(),
+            OrderOverview::class => new OrderOverviewSerializer(),
         ];
     }
 

--- a/src/Serializer/TrackAndTraceSerializer.php
+++ b/src/Serializer/TrackAndTraceSerializer.php
@@ -42,8 +42,11 @@ class TrackAndTraceSerializer implements SerializerInterface
         }
 
         $trackingDetail->setDetails($details);
-        $trackingDetail->setDistributor($serializer->deserialize($data['distributor'], Distributor::class));
 
+        if (null !== $data['distributor']) {
+            $trackingDetail->setDistributor($serializer->deserialize($data['distributor'], Distributor::class));
+        }
+        
         return $trackingDetail;
     }
 }

--- a/src/Serializer/TrackingDetailSerializer.php
+++ b/src/Serializer/TrackingDetailSerializer.php
@@ -35,7 +35,11 @@ class TrackingDetailSerializer implements SerializerInterface
         $trackingDetail->setCode($data['code']);
         $trackingDetail->setStatus($data['status']);
         $trackingDetail->setDescription($data['description']);
-        $trackingDetail->setDate(new DateTime($data['date']));
+
+        // API versioning: v2.
+        if (array_key_exists('datetime', $data)) {
+            $trackingDetail->setDate(new DateTime($data['datetime']));
+        }
 
         return $trackingDetail;
     }

--- a/tests/ClientFactoryTest.php
+++ b/tests/ClientFactoryTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
  */
 class ClientFactoryTest extends TestCase
 {
-    public function testBuild()
+    public function testBuild(): void
     {
         // Arrange
         $clientId = 'test_clientId';

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -48,37 +48,38 @@ class ClientTest extends TestCase
         $accessToken = 'test_accessToken';
 
         $this->httpClientMock
-            ->expects($this->at(0))
+            ->expects($this->exactly(2))
             ->method('request')
-            ->with(
-                'POST',
-                '/token',
+            ->withConsecutive(
                 [
-                    'body' => [
-                        'grant_type' => 'client_credentials',
-                        'client_id' => $clientId,
-                        'client_secret' => $clientSecret,
-                    ],
+                    'POST',
+                    '/token',
+                    [
+                        'body' => [
+                            'grant_type' => 'client_credentials',
+                            'client_id' => $clientId,
+                            'client_secret' => $clientSecret,
+                        ],
+                    ]
+                ],
+                [
+                    'GET',
+                    $endpoint,
+                    [
+                        'headers' => [
+                            'Authorization' => sprintf('Bearer %s', $accessToken),
+                            'User-Agent' => ''
+                        ],
+                        'json' => [],
+                        'query' => [],
+                    ]
                 ]
             )
-            ->willReturn($this->authorizationResponseMock);
+            ->willReturnOnConsecutiveCalls($this->authorizationResponseMock, $this->responseMock);
 
         $this->authorizationResponseMock
             ->method('getContent')
             ->willReturn(sprintf('{"access_token":"%s"}', $accessToken));
-
-        $this->httpClientMock
-            ->expects($this->at(1))
-            ->method('request')
-            ->with('GET', $endpoint, [
-                'headers' => [
-                    'Authorization' => sprintf('Bearer %s', $accessToken),
-                    'User-Agent' => ''
-                ],
-                'json' => [],
-                'query' => [],
-            ])
-            ->willReturn($this->responseMock);
 
         $this->responseMock
             ->method('getContent')
@@ -111,7 +112,7 @@ class ClientTest extends TestCase
         $clientSecret = 'test_clientSecret';
 
         $this->httpClientMock
-            ->expects($this->at(0))
+            ->expects($this->once())
             ->method('request')
             ->with(
                 'POST',
@@ -136,8 +137,6 @@ class ClientTest extends TestCase
 
     public function setUp(): void
     {
-        parent::setUp();
-
         $this->httpClientMock = $this->createMock(HttpClientInterface::class);
         $this->authorizationResponseMock = $this->createMock(ResponseInterface::class);
         $this->responseMock = $this->createMock(ResponseInterface::class);

--- a/tests/Endpoints/LabelEndpointTest.php
+++ b/tests/Endpoints/LabelEndpointTest.php
@@ -34,7 +34,7 @@ class LabelEndpointTest extends TestCase
      */
     private $labelMock;
 
-    public function testGet()
+    public function testGet(): void
     {
         // Arrange
         $id = $this->getFaker()->uuid;
@@ -60,7 +60,7 @@ class LabelEndpointTest extends TestCase
         $this->assertSame($this->labelMock, $response);
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->clientMock = $this->createMock(Client::class);
         $this->serializerMock = $this->createMock(Serializer::class);

--- a/tests/Endpoints/MeEndpointTest.php
+++ b/tests/Endpoints/MeEndpointTest.php
@@ -34,7 +34,7 @@ class MeEndpointTest extends TestCase
      */
     private $meMock;
 
-    public function testGet()
+    public function testGet(): void
     {
         // Arrange
         $id = $this->getFaker()->uuid;
@@ -60,7 +60,7 @@ class MeEndpointTest extends TestCase
         $this->assertSame($this->meMock, $response);
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->clientMock = $this->createMock(Client::class);
         $this->serializerMock = $this->createMock(Serializer::class);

--- a/tests/Endpoints/ShipmentEndpointTest.php
+++ b/tests/Endpoints/ShipmentEndpointTest.php
@@ -34,7 +34,7 @@ class ShipmentEndpointTest extends TestCase
      */
     private $shipmentMock;
 
-    public function testGet()
+    public function testGet(): void
     {
         // Arrange
         $id = $this->getFaker()->uuid;
@@ -58,7 +58,7 @@ class ShipmentEndpointTest extends TestCase
         $this->assertSame($this->shipmentMock, $response);
     }
 
-    public function testCreate()
+    public function testCreate(): void
     {
         // Arrange
         $serializedShipment = [
@@ -93,10 +93,8 @@ class ShipmentEndpointTest extends TestCase
         $endpoint->create($shipment);
     }
 
-    public function setUp()
+    public function setUp(): void
     {
-        parent::setUp();
-
         $this->clientMock = $this->createMock(Client::class);
         $this->serializerMock = $this->createMock(Serializer::class);
         $this->shipmentMock = $this->createMock(Shipment::class);

--- a/tests/Endpoints/TrackingEndpointTest.php
+++ b/tests/Endpoints/TrackingEndpointTest.php
@@ -32,11 +32,11 @@ class TrackingEndpointTest extends TestCase
     private $serializerMock;
 
     /**
-     * @var Tracking|MockObject
+     * @var TrackAndTrace|MockObject
      */
     private $trackingMock;
 
-    public function testGet()
+    public function testGet(): void
     {
         // Arrange
         $id = $this->getFaker()->uuid;
@@ -60,10 +60,8 @@ class TrackingEndpointTest extends TestCase
         $this->assertSame($this->trackingMock, $response);
     }
 
-    public function setUp()
+    public function setUp(): void
     {
-        parent::setUp();
-
         $this->clientMock = $this->createMock(Client::class);
         $this->serializerMock = $this->createMock(Serializer::class);
         $this->trackingMock = $this->createMock(TrackAndTrace::class);

--- a/tests/Serializer/ShipmentSerializerTest.php
+++ b/tests/Serializer/ShipmentSerializerTest.php
@@ -15,7 +15,7 @@ class ShipmentSerializerTest extends TestCase
 {
     use FakerTrait;
 
-    public function testShipment()
+    public function testShipment(): void
     {
         $shipmentItem = new Item();
         $shipmentItem->setCustomerReference('Hello');


### PR DESCRIPTION
* Fix PHP 8 compatibility.
* Add `ClientFactory::buildClient` and `Client->setAccessToken()` to authenticate without ID/Secret.
* Add relation->id to Me endpoint.
* Add ExternalOrder FindByExternalId, Update, Delete.
* Add endpoint to create Shopify integration, gets client credentials in response.